### PR TITLE
Improve Discord alerts

### DIFF
--- a/main.go
+++ b/main.go
@@ -428,6 +428,14 @@ func getWickets(score string) int {
 func sendDiscordAlert(config Config, title string, color int, state *MatchState) {
 	var fields []DiscordEmbedField
 
+	// Reason for the alert
+	fields = append(fields, DiscordEmbedField{Name: "Alert", Value: title, Inline: false})
+
+	// Match status
+	if state.Status != "" {
+		fields = append(fields, DiscordEmbedField{Name: "Status", Value: state.Status, Inline: false})
+	}
+
 	// Main Score and Overs
 	if state.Score != "" {
 		scoreValue := fmt.Sprintf("%s (%s)", state.Score, state.Overs)


### PR DESCRIPTION
## Summary
- improve Discord alert formatting
- include reason for the alert and match status

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6871ec9db1cc83328cfdede1ae01722d