### PR TITLE
Add Discord alert API and multi-webhook support

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,1 @@
-DISCORD_WEBHOOK_URL=https://discord.com/api/webhooks/1393248326077386952/57qoetfhSiY-NP6qId_AH4wgE8vCyk4uw9ik0ns_GwoTkH12NktwNU-NjN6eUfhY_Xt-
+DISCORD_WEBHOOK_URLS=https://discord.com/api/webhooks/your-webhook-id-1/abcdef,https://discord.com/api/webhooks/your-webhook-id-2/ghijkl


### PR DESCRIPTION
## Summary
- support multiple Discord webhooks via `DISCORD_WEBHOOK_URLS`
- add HTTP server with `/alert` and `/score` endpoints
- send alerts to all configured webhooks

## Testing
- `go build ./...`

------
https://chatgpt.com/codex/tasks/task_e_6871f410119083329b6b22e689f645db